### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,16 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-oauth": "~0.16"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require":     {
     "php": "^8.3",
     "laravel/helpers": "^1.8",
-    "dreamfactory/df-oauth": "~0.16"
+    "dreamfactory/df-oauth": "~1.0"
   },
   "require-dev": {
     "laravel/framework": "^13.7",


### PR DESCRIPTION
## Release prep: cut develop into master (NOTE: master ahead of develop)

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

> ⚠️ `master` has commits not in `develop` — listed below. GitHub will
> create a merge commit; both histories are preserved. Reviewer:
> verify the divergent master commits aren't logically conflicting
> with the develop work before merging.

### Verification

The develop HEAD here is the SHA locked into the L13/PHP 8.5 test
bundle. **Full end-to-end smoke passed 2026-05-26** (PHP 8.5.5,
Laravel 13.11.2, df:setup, login, CRUD, OpenAPI gen).

### Coordinated release PRs

One of ~26 coordinated release PRs. Merge order:
foundation → connectors → auth → services → AI → admin UI → host app.
